### PR TITLE
Cope with temp being N/A

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -306,11 +306,16 @@ function _lp_init --description 'Initialize liquidprompt'
         # Return the average system temperature we get through the sensors command
         set -l count 0
         set -l temperature 0
-        for i in (sensors | grep -E "^(Core|temp)" | sed -r "s/.*: *\+([0-9]*)\..°.*/\1/g")
+        set -l tempregex ":\s*[^-]([0-9]+(\.[0-9]+)?)\s*°"
+        for i in (sensors | grep -E "^(Core|temp).*$tempregex" | sed -r "s/.*$tempregex.*/\1/g")
             set temperature (math "$temperature + $i")
             set count (math "$count + 1")
         end
-        echo -ne (math "$temperature / $count")
+        if test $count -ne 0
+            echo -ne (math "$temperature / $count")
+        else
+            echo -ne 0
+        end
     end
 
     function _lp_temperature --description 'Print the temperature'

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -306,7 +306,7 @@ function _lp_init --description 'Initialize liquidprompt'
         # Return the average system temperature we get through the sensors command
         set -l count 0
         set -l temperature 0
-        set -l tempregex ":\s*[^-]([0-9]+(\.[0-9]+)?)\s*°"
+        set -l tempregex ":\s*\+?([0-9]+(\.[0-9]+)?)\s*°"
         for i in (sensors | grep -E "^(Core|temp).*$tempregex" | sed -r "s/.*$tempregex.*/\1/g")
             set temperature (math "$temperature + $i")
             set count (math "$count + 1")


### PR DESCRIPTION
now it can handle `sensors` output like this:

```
> sensors
acpitz-virtual-0
Adapter: Virtual device
temp1:        +61.0°C  (crit = +127.0°C)
temp2:        +56.0°C  (crit = +100.0°C)

thinkpad-isa-0000
Adapter: ISA adapter
fan1:        3042 RPM
temp1:        +61.0°C  
temp2:        +58.0°C  
temp3:        +45.0°C  
temp4:        +81.0°C  
temp5:            N/A  
temp6:            N/A  
temp7:            N/A  
temp8:            N/A  
temp9:        +47.0°C  
temp10:       +62.0°C  
temp11:       +62.0°C  
temp12:           N/A  
temp13:           N/A  
temp14:           N/A  
temp15:           N/A  
temp16:           N/A  

coretemp-isa-0000
Adapter: ISA adapter
Core 0:       +56.0°C  (high = +105.0°C, crit = +105.0°C)
Core 1:       +56.0°C  (high = +105.0°C, crit = +105.0°C)
```

before:

```
> sensors | grep -E "^(Core|temp)" | sed -r "s/.*: *\+([0-9]*)\..°.*/\1/g"
67
62
67
62
46
85
temp5:            N/A  
temp6:            N/A  
temp7:            N/A  
temp8:            N/A  
50
65
66
temp12:           N/A  
temp13:           N/A  
temp14:           N/A  
temp15:           N/A  
temp16:           N/A  
61
61
```

now:

```
> sensors | grep -E "^(Core|temp).*:\s*[^-]([0-9]+(\.[0-9]+)?)\s*°" | sed -r "s/.*:\s*[^-]([0-9]+(\.[0-9]+)?)\s*°.*/\1/g"
65.0
60.0
65.0
62.0
46.0
85.0
50.0
65.0
65.0
60.0
60.0
```
